### PR TITLE
Add refresh automation for london-life-expectancy

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,39 @@
+name: Update london-life-expectancy dataset
+
+on:
+  schedule:
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+
+      - name: Run updater
+        run: python scripts/london-life-expectancy.py
+
+      - name: Commit and push if changed
+        run: |
+          git config --global user.email "actions@users.noreply.github.com"
+          git config --global user.name "Automated commit"
+          git diff --quiet && echo "No changes to commit" || (
+            git add data/ datapackage.json &&
+            git commit -m "Automated commit" &&
+            git push origin main
+          )

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,12 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-04
+
+- Re-ran `scripts/london-life-expectancy.py` and verified the existing pipeline still executes against the London Datastore XLS endpoint.
+- Added first GitHub Actions automation workflow at `.github/workflows/actions.yml` with:
+  - monthly schedule,
+  - manual `workflow_dispatch`,
+  - `contents: write` permissions,
+  - commit-if-changed behavior for `data/` and `datapackage.json`.
+- The current script source remains limited to 2016-2018 content from the legacy London Datastore file.
+- Freshness beyond 2016-2018 requires migration to newer ONS successor datasets (latest coverage: 2022-2024), which use a different publication path than the legacy URL in the script.


### PR DESCRIPTION
## Summary
- add scheduled/manual GitHub Actions automation with `contents: write` permissions to rerun the existing life expectancy updater
- add commit-if-changed behavior for generated files so monthly refreshes can persist automatically
- add a root maintenance report documenting that the legacy London Datastore source is frozen at 2016-2018 and that a separate ONS successor migration is needed for newer coverage